### PR TITLE
Fixed global search

### DIFF
--- a/_posts/2024-08-22-linux-bashrczshrc.md
+++ b/_posts/2024-08-22-linux-bashrczshrc.md
@@ -11,8 +11,8 @@ categories: [OS,Linux]
 #fastfetch
 
 # Clears Bash/Zsh History
-#echo "" > ~/.bash_history && \
-#echo "" > ~/.zsh_history && \
+#echo "" > ~/.bash_history
+#echo "" > ~/.zsh_history
 # "-c" for Bash and "-p" for Zsh (may need to adjust history alias if errors show up)
 #history -c
 #history -p

--- a/_posts/2024-08-22-windows11-bypass.md
+++ b/_posts/2024-08-22-windows11-bypass.md
@@ -54,7 +54,7 @@ categories: [OS,Windows]
 ~~2. Type:~~
 
     ```c++
-    oobe\bypassnro
+    oobe\\bypassnro
     ```
 
 ---

--- a/_posts/2024-08-22-windows11-fixes-and-tweaks.md
+++ b/_posts/2024-08-22-windows11-fixes-and-tweaks.md
@@ -1,5 +1,5 @@
 ---
-title: Windows 11 - Tweaks
+title: Windows 11 - Fixes and Tweaks
 categories: [OS,Windows]
 ---
 
@@ -8,7 +8,7 @@ categories: [OS,Windows]
 1. Create a new shortcut and enter the following path:
 
     ```c++
-    %windir%\system32\rundll32.exe advapi32.dll,ProcessIdleTasks
+    %windir%/system32/rundll32.exe advapi32.dll,ProcessIdleTasks
     ```
 
 ## Mini-Tray Clear Duplicates (Batch)
@@ -16,7 +16,7 @@ categories: [OS,Windows]
 1. Open Command Prompt and type:
 
     ```c++
-    reg.exe delete "HKCU\Control Panel\NotifyIconSettings" /f
+    reg.exe delete "HKCU/Control Panel/NotifyIconSettings" /f
     ```
 
 2. You may need to restart Windows Explorer (it should do it automatically).

--- a/_posts/2024-08-22-windows11-fixes-and-tweaks.md
+++ b/_posts/2024-08-22-windows11-fixes-and-tweaks.md
@@ -7,28 +7,19 @@ categories: [OS,Windows]
 
 1. Create a new shortcut and enter the following path:
 
-    ```c++
-    %windir%/system32/rundll32.exe advapi32.dll,ProcessIdleTasks
+    ```batch
+    %windir%\\system32\\rundll32.exe advapi32.dll,ProcessIdleTasks
     ```
 
 ## Mini-Tray Clear Duplicates (Batch)
 
 1. Open Command Prompt and type:
 
-    ```c++
-    reg.exe delete "HKCU/Control Panel/NotifyIconSettings" /f
+    ```batch
+    reg.exe delete "HKCU\\Control Panel\\NotifyIconSettings" /f
     ```
 
 2. You may need to restart Windows Explorer (it should do it automatically).
-
----
-
-## Spice Fixes (if running with KVM)
-
-1. Download the ISO for [VirtIO](https://github.com/virtio-win/virtio-win-pkg-scripts/blob/master/README.md) and run it through **before** fully installing Windows.
-2. Tested EXE helps with performance, but most users suggest that Windows might agree with doing it after the installation. Test at your own risk.
-3. Install this EXE and reboot:
-    - [Windows Spice Guest Tools](https://github.com/virtio-win/virtio-win-pkg-scripts/blob/master/README.md)
 
 ---
 
@@ -37,14 +28,14 @@ categories: [OS,Windows]
 1. Open Terminal as Administrator.
 2. Type:
 
-    ```c++
+    ```batch
     net user Administrator /active:yes
     ```
 
 3. To disable, set "yes" to "no".
 4. Set password:
 
-    ```c++
+    ```batch
     net user administrator *
     ```
 

--- a/_posts/2024-08-22-windows11-powershell-tweaks.md
+++ b/_posts/2024-08-22-windows11-powershell-tweaks.md
@@ -5,7 +5,7 @@ categories: [OS,Windows,PowerShell]
 
 ## Clear Terminal History
 
-**PATH:** `C:\Users\YOURUSERNAME\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadLine\ConsoleHost_history.txt`
+**PATH:** `C:/Users/YOURUSERNAME/AppData/Roaming/Microsoft/Windows/PowerShell/PSReadLine/ConsoleHost_history.txt`
 
 1. Create PROFILE PATH (reference output of `echo $PROFILE`)
    - Example: `C:\Users\YOURUSERNAME\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`
@@ -32,8 +32,6 @@ categories: [OS,Windows,PowerShell]
    ```powershell
    Install-Script winfetch
    ```
-
-Source: [WinFetch Installation](https://github.com/lptstr/winfetch/wiki/Installation)
 
 ---
 
@@ -64,4 +62,8 @@ Source: [WinFetch Installation](https://github.com/lptstr/winfetch/wiki/Installa
    . $PROFILE
    ```
 
-Source: [Oh-My-Posh Installation](https://ohmyposh.dev/docs/installation/windows)
+## Sources
+
+[WinFetch Installation](https://github.com/lptstr/winfetch/wiki/Installation)
+
+[Oh-My-Posh Installation](https://ohmyposh.dev/docs/installation/windows)

--- a/_posts/2024-08-22-windows11-powershell-tweaks.md
+++ b/_posts/2024-08-22-windows11-powershell-tweaks.md
@@ -5,19 +5,22 @@ categories: [OS,Windows,PowerShell]
 
 ## Clear Terminal History
 
-**PATH:** `C:/Users/YOURUSERNAME/AppData/Roaming/Microsoft/Windows/PowerShell/PSReadLine/ConsoleHost_history.txt`
+**PATH:** `C:\\Users\\YOURUSERNAME\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadLine\\ConsoleHost_history.txt`
 
-1. Create PROFILE PATH (reference output of `echo $PROFILE`)
-   - Example: `C:\Users\YOURUSERNAME\Documents\PowerShell\Microsoft.PowerShell_profile.ps1`
-2. Add these commands to the file:
+1. Create PROFILE PATH (reference output of below if one exists:)
+```powershell
+echo $PROFILE
+```
+  - If environment doesn't exist, create one like below
+  - Example: `C:\\Users\\YOURUSERNAME\\Documents\\PowerShell\\Microsoft.PowerShell_profile.ps1`
+1. Add these commands to the file:
 
    ```powershell
    Clear-History
-   echo "" > C:\Users\YOURUSERNAME\AppData\Roaming\Microsoft\Windows\PowerShell\PSReadLine\ConsoleHost_history.txt
+   echo "" > C:\\Users\\YOURUSERNAME\\AppData\\Roaming\\Microsoft\\Windows\\PowerShell\\PSReadLine\\ConsoleHost_history.txt
    ```
 
-3. Save the file and restart the shell
-4. Or type:
+2. Save the file and restart the shell or enter:
 
    ```powershell
    . $PROFILE
@@ -53,7 +56,7 @@ categories: [OS,Windows,PowerShell]
 4. Set this to `$PROFILE`:
 
    ```powershell
-   oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\jandedobbeleer.omp.json" | Invoke-Expression
+   oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH\\jandedobbeleer.omp.json" | Invoke-Expression
    ```
 
 5. Recommend appending this to the top just in case this messes with anything:


### PR DESCRIPTION
Fix for #38 by removing `\` in contents of posts and replacing with `/`

Note that this may cause problems for people copy-pasting PATHS since Windows more than likely won't recognize this